### PR TITLE
Cubic bezier temporal easing

### DIFF
--- a/src/catmullrom.rs
+++ b/src/catmullrom.rs
@@ -1,4 +1,3 @@
-
 use gee::en::{self};
 use time_point::Duration;
 

--- a/src/catmullrom.rs
+++ b/src/catmullrom.rs
@@ -7,6 +7,8 @@ const UNIFORM_ALPHA: f64 = 0.0;
 const CENTRIPETAL_ALPHA: f64 = 0.5;
 const CHORDAL_ALPHA: f64 = 1.0;
 
+const TANGENT_EPSILON: f64 = 1e-5;
+
 pub fn catmull_rom_value<X: en::Num, Y: en::Num>(
     p0: &Coordinate<X, Y>,
     p1: &Coordinate<X, Y>,
@@ -53,16 +55,94 @@ pub fn catmull_rom_value<X: en::Num, Y: en::Num>(
     let d3t = t3 - t;
     let dt0 = t - t0;
 
-    let a1 = (*p0 * (d1t / d10)) + (*p1 * (dt0 / d10));
-    let a2 = (*p1 * (d2t / d21)) + (*p2 * (-d1t / d21));
-    let a3 = (*p2 * (d3t / d32)) + (*p3 * (-d2t / d32));
+    let a1 = if d10 != 0.0 {
+        (*p0 * (d1t / d10)) + (*p1 * (dt0 / d10))
+    } else {
+        *p0
+    };
+    let a2 = if d21 != 0.0 {
+        (*p1 * (d2t / d21)) + (*p2 * (-d1t / d21))
+    } else {
+        *p1
+    };
+    let a3 = if d32 != 0.0 {
+        (*p2 * (d3t / d32)) + (*p3 * (-d2t / d32))
+    } else {
+        *p2
+    };
 
-    let b1 = (a1 * (d2t / d20)) + (a2 * (dt0 / d20));
-    let b2 = (a2 * (d3t / d31)) + (a3 * (-d1t / d31));
+    let b1 = if d20 != 0.0 {
+        (a1 * (d2t / d20)) + (a2 * (dt0 / d20))
+    } else {
+        a1
+    };
+    let b2 = if d31 != 0.0 {
+        (a2 * (d3t / d31)) + (a3 * (-d1t / d31))
+    } else {
+        a2
+    };
 
-    let c = (b1 * (d2t / d21)) + (b2 * (-d1t / d21));
+    let c = if d21 != 0.0 {
+        (b1 * (d2t / d21)) + (b2 * (-d1t / d21))
+    } else {
+        b1
+    };
 
     c
+}
+
+// Convert non-uniform catmull rom to equivalent bezier spline
+//
+// Uses numerical approximation
+pub fn catmull_rom_to_bezier<X: en::Num, Y: en::Num>(
+    p0: &Coordinate<X, Y>,
+    p1: &Coordinate<X, Y>,
+    p2: &Coordinate<X, Y>,
+    p3: &Coordinate<X, Y>,
+    t0: f64,
+    t1: f64,
+    t2: f64,
+    t3: f64,
+) -> (
+    Coordinate<X, Y>,
+    Coordinate<X, Y>,
+    Coordinate<X, Y>,
+    Coordinate<X, Y>,
+) {
+    // Inner knot distance
+    let s = t2 - t1;
+
+    // Sample central difference around start and end
+    let a1 = catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, t1 - s * TANGENT_EPSILON);
+    let b1 = catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, t1 + s * TANGENT_EPSILON);
+
+    let a2 = catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, t2 - s * TANGENT_EPSILON);
+    let b2 = catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, t2 + s * TANGENT_EPSILON);
+
+    // Scale to appropriate range
+    // Bezier has factor of 3, central difference has factor of 2
+    let d1 = (b1 - a1) * (1.0 / (TANGENT_EPSILON * 6.0));
+    let d2 = (a2 - b2) * (1.0 / (TANGENT_EPSILON * 6.0));
+
+    (*p1, *p1 + d1, *p2 + d2, *p2)
+}
+
+// Cubic bezier with endpoints p0 / p3 and control points p1 / 2
+pub fn bezier_value<X: en::Num, Y: en::Num>(
+    p0: &Coordinate<X, Y>,
+    p1: &Coordinate<X, Y>,
+    p2: &Coordinate<X, Y>,
+    p3: &Coordinate<X, Y>,
+    t: f64,
+) -> Coordinate<X, Y> {
+    let t2 = t * t;
+    let t3 = t * t2;
+
+    let it = 1.0 - t;
+    let it2 = it * it;
+    let it3 = it * it2;
+
+    *p0 * it3 + *p1 * it2 * (3.0 * t) + *p2 * it * (3.0 * t2) + *p3 * t3
 }
 
 // Calculate values of T for a given alpha
@@ -90,10 +170,11 @@ pub fn centripetal_catmull_rom<X: en::Num, Y: en::Num>(
     p3: Coordinate<X, Y>,
     t: f64,
 ) -> Coordinate<X, Y> {
-    let _t = t_values(&p0, &p1, &p2, &p3, CENTRIPETAL_ALPHA);
+    let (t0, t1, t2, t3) = t_values(&p0, &p1, &p2, &p3, CENTRIPETAL_ALPHA);
+
     // Our input t value ranges from 0-1, and needs to be scaled to match the spline's knots
-    let adjusted_t = _t.1 + ((_t.2 - _t.1) * t);
-    catmull_rom_value(&p0, &p1, &p2, &p3, _t.0, _t.1, _t.2, _t.3, adjusted_t)
+    let adjusted_t = t1 + ((t2 - t1) * t);
+    catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, adjusted_t)
 }
 
 pub fn catmull_rom_time_scale(
@@ -122,4 +203,95 @@ pub fn catmull_rom_time_scale(
     .y;
 
     Duration::new((relative_elapsed_spline_time * d3.nanos as f64) as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Accuracy threshold for matching curves
+    const TEST_EPSILON: f64 = 1e-7;
+
+    // Steps to divide curve into
+    const TEST_STEPS: usize = 1000;
+
+    #[test]
+    fn test_match_cr_bez() {
+        let p1 = Coordinate::new(0.0, 0.0);
+        let p2 = Coordinate::new(1.0, 0.0);
+        let p3 = Coordinate::new(2.0, 2.1);
+        let p4 = Coordinate::new(-1.0, 4.0);
+
+        let t1: f64 = -0.04;
+        let t2: f64 = 0.15;
+        let t3: f64 = 0.2;
+        let t4: f64 = 0.3;
+
+        let bezier = catmull_rom_to_bezier(&p1, &p2, &p3, &p4, t1, t2, t3, t4);
+        let b1 = bezier.0;
+        let b2 = bezier.1;
+        let b3 = bezier.2;
+        let b4 = bezier.3;
+
+        println!("b1 = {}, {}", b1.x, b1.y);
+        println!("b2 = {}, {}", b2.x, b2.y);
+        println!("b3 = {}, {}", b3.x, b3.y);
+        println!("b4 = {}, {}", b4.x, b4.y);
+
+        for i in 0..=TEST_STEPS {
+            let d = (i as f64) / (TEST_STEPS as f64);
+            let cr = catmull_rom_value(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
+            let bz = bezier_value(&b1, &b2, &b3, &b4, d);
+
+            assert!(
+                cr.distance_to(&bz) < TEST_EPSILON,
+                "bezier does not match catmull rom at {}: {},{} != {},{}",
+                d,
+                cr.x,
+                cr.y,
+                bz.x,
+                bz.y
+            );
+        }
+    }
+
+    #[test]
+    fn test_degen_knots() {
+        let p1 = Coordinate::new(0.0, 0.0);
+        let p2 = p1;
+        let p3 = Coordinate::new(2.0, 0.0);
+        let p4 = Coordinate::new(-1.0, 4.0);
+
+        let t1: f64 = -0.1;
+        let t2: f64 = t1;
+        let t3: f64 = 0.2;
+        let t4: f64 = 0.3;
+
+        let bezier = catmull_rom_to_bezier(&p1, &p2, &p3, &p4, t1, t2, t3, t4);
+        let b1 = bezier.0;
+        let b2 = bezier.1;
+        let b3 = bezier.2;
+        let b4 = bezier.3;
+
+        println!("b1 = {}, {}", b1.x, b1.y);
+        println!("b2 = {}, {}", b2.x, b2.y);
+        println!("b3 = {}, {}", b3.x, b3.y);
+        println!("b4 = {}, {}", b4.x, b4.y);
+
+        for i in 0..=TEST_STEPS {
+            let d = (i as f64) / (TEST_STEPS as f64);
+            let cr = catmull_rom_value(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
+            let bz = bezier_value(&b1, &b2, &b3, &b4, d);
+
+            assert!(
+                cr.distance_to(&bz) < TEST_EPSILON,
+                "bezier does not match catmull rom at {}: {},{} != {},{}",
+                d,
+                cr.x,
+                cr.y,
+                bz.x,
+                bz.y
+            );
+        }
+    }
 }

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -28,6 +28,14 @@ impl<X: en::Num, Y: en::Num> std::ops::Add for Coordinate<X, Y> {
     }
 }
 
+impl<X: en::Num, Y: en::Num> std::ops::Sub for Coordinate<X, Y> {
+    type Output = Coordinate<X, Y>;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
 impl<X: en::Num, Y: en::Num> std::ops::Mul<f64> for Coordinate<X, Y> {
     type Output = Coordinate<X, Y>;
 

--- a/src/ease/bezier.rs
+++ b/src/ease/bezier.rs
@@ -1,0 +1,219 @@
+// Newton-Raphson iterations
+const NR_ITERATIONS: usize = 3;
+
+#[allow(dead_code)]
+pub fn cubic_bezier_ease(ox: f64, oy: f64, ix: f64, iy: f64, t: f64) -> f64 {
+    // Uses a cubic 2D bezier curve to map linear interpolation time
+    // to eased interpolation time.
+    //
+    // https://cubic-bezier.com
+    //
+    // Bezier control points:
+    // [0, 0], [ox, oy], [ix, iy], [1, 1]
+    //
+    // The easing curve is parametric and
+    // defined by (s ∈ [0, 1]):
+    //
+    // x(s) = bezier X
+    // y(s) = bezier Y
+    //
+    // The output is found by inverting x(s) and composing it with y(s):
+    // out = y(x^-1(t))
+    //
+    // Note that Y is allowed to exceed [0, 1] to allow under/overshoot
+    // of 1D interpolation. But X is always monotonic (= invertible).
+    //
+    // Multiple cubic eases are typically chained so that the in
+    // and out tangents line up at every keyframe.
+    //
+    // For 2D path-based animation, this temporal easing is applied
+    // to each individual spatial spline segment, after rectifying it
+    // by arc length. These motions never go backwards along the path,
+    // so both X and Y will be monotonic.
+
+    // Extend the curve beyond start and end by mirroring/flipping
+    // This allows good central differences to be taken around start/end
+    if t < 0.0 {
+        -lookup(ox, oy, ix, iy, -t)
+    } else if t > 1.0 {
+        2.0 - lookup(ox, oy, ix, iy, 2.0 - t)
+    } else {
+        lookup(ox, oy, ix, iy, t)
+    }
+}
+
+fn lookup(ox: f64, oy: f64, ix: f64, iy: f64, t: f64) -> f64 {
+    bezier(oy, iy, invert_bezier(ox, ix, t))
+}
+
+fn square(x: f64) -> f64 {
+    x * x
+}
+fn cube(x: f64) -> f64 {
+    x * x * x
+}
+
+// Exact x(t) with fixed first and last control point
+pub fn bezier(ox: f64, ix: f64, t: f64) -> f64 {
+    let it = 1.0 - t;
+    ox * 3.0 * square(it) * t + ix * 3.0 * it * square(t) + cube(t)
+}
+
+// Exact dx(t)/dt with fixed first and last control point
+pub fn dt_bezier(ox: f64, ix: f64, t: f64) -> f64 {
+    3.0 * (ox * (1.0 - t * (4.0 - 3.0 * t)) + t * (ix * (2.0 - 3.0 * t) + t))
+}
+
+// Approximate t = x^-1(x)
+pub fn invert_bezier(ox: f64, ix: f64, x: f64) -> f64 {
+    // Use Newton-Raphson iteration starting from the input time
+    //
+    // Converges O(1/n^2) almost everywhere,
+    // except near horizontal tangents where it is O(1/n).
+    let mut t = x;
+    for _ in 1..=NR_ITERATIONS {
+        let v = bezier(ox, ix, t) - x;
+        let dvdt = dt_bezier(ox, ix, t);
+
+        if v == 0.0 {
+            break;
+        }
+        if dvdt == 0.0 {
+            break;
+        }
+
+        t = t - v / dvdt;
+    }
+
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tolerance for testing numerical accuracy
+    const TEST_TOLERANCE_EXACT: f64 = 1e-7;
+    const TEST_TOLERANCE_APPROX: f64 = 1e-3;
+
+    // Step size for epsilon/delta slope test
+    const TEST_SLOPE_DELTA: f64 = 1e-6;
+    const TEST_SLOPE_EPSILON: f64 = 1e-4;
+
+    // Number of steps along curve to test
+    const TEST_STEPS: usize = 1000;
+
+    pub fn approx_eq(lhs: f64, rhs: f64, epsilon: f64) -> bool {
+        lhs.is_finite() && rhs.is_finite() && ((lhs - epsilon)..(lhs + epsilon)).contains(&rhs)
+    }
+
+    #[test]
+    fn test() {
+        // Three different parametrizations of a diagonal
+        test_curve(0.166, 0.166, 0.833, 0.833);
+        test_curve(0.333, 0.333, 0.666, 0.666);
+        test_curve(0.1, 0.1, 0.666, 0.666);
+
+        // Slight curve
+        test_curve(0.125, 0.166, 0.833, 0.833);
+
+        // Ease-out
+        test_curve(0.166, 0.0, 0.833, 0.833);
+
+        // Ease-in
+        test_curve(0.166, 0.166, 0.833, 1.0);
+
+        // Ease-in-out
+        test_curve(0.125, 0.0, 0.833, 1.0);
+
+        // Strong ease-in-out
+        test_curve(0.333, 0.0, 0.666, 1.0);
+
+        // Overshoot/undershoot
+        test_curve(0.166, -0.25, 0.833, 1.25);
+    }
+
+    fn test_curve(ox: f64, oy: f64, ix: f64, iy: f64) {
+        test_invert(ox, ix);
+        test_smooth(ox, oy, ix, iy);
+        test_slope(ox, oy, ix, iy);
+    }
+
+    // Test if x(x^-1(t)) is within tolerance everywhere
+    fn test_invert(ox: f64, ix: f64) {
+        let step: f64 = 1.0 / (TEST_STEPS as f64);
+        for i in 0..=TEST_STEPS {
+            let ti = (i as f64) * step;
+
+            let to = invert_bezier(ox, ix, ti);
+            let tti = bezier(ox, ix, to);
+
+            assert!(
+                approx_eq(tti, ti, TEST_TOLERANCE_EXACT),
+                "identity failed on 1D cubic bezier {} {} at {} != {}",
+                ox,
+                ix,
+                ti,
+                tti
+            )
+        }
+    }
+
+    // Test curve smoothness
+    // Check if each point is near the average of its neighbors
+    fn test_smooth(ox: f64, oy: f64, ix: f64, iy: f64) {
+        let step: f64 = 1.0 / (TEST_STEPS as f64);
+
+        for i in 0..=TEST_STEPS {
+            let ti = (i as f64) * step;
+
+            let to1 = cubic_bezier_ease(ox, oy, ix, iy, ti - step);
+            let to2 = cubic_bezier_ease(ox, oy, ix, iy, ti);
+            let to3 = cubic_bezier_ease(ox, oy, ix, iy, ti + step);
+
+            let mid = (to1 + to3) / 2.0;
+            let error = (mid - to2).abs();
+
+            assert!(
+                error < TEST_TOLERANCE_APPROX,
+                "curve is not smooth at {}: {} {} {}",
+                ti,
+                to1,
+                to2,
+                to3
+            );
+        }
+    }
+
+    // Check if start/end slopes match the 2D bezier tangents
+    fn test_slope(ox: f64, oy: f64, ix: f64, iy: f64) {
+        // Use central difference around start and end
+        let t_out2 = cubic_bezier_ease(ox, oy, ix, iy, TEST_SLOPE_DELTA);
+        let t_out1 = cubic_bezier_ease(ox, oy, ix, iy, -TEST_SLOPE_DELTA);
+
+        let t_in2 = cubic_bezier_ease(ox, oy, ix, iy, 1.0 + TEST_SLOPE_DELTA);
+        let t_in1 = cubic_bezier_ease(ox, oy, ix, iy, 1.0 - TEST_SLOPE_DELTA);
+
+        // Get slopes
+        let slope_out = (t_out2 - t_out1) / (2.0 * TEST_SLOPE_DELTA);
+        let slope_in = (t_in2 - t_in1) / (2.0 * TEST_SLOPE_DELTA);
+
+        assert!(
+            approx_eq(slope_out, oy / ox, TEST_SLOPE_EPSILON),
+            "out slope doesn't match {} {}:  {} != {}",
+            ox,
+            oy,
+            oy / ox,
+            slope_out,
+        );
+
+        assert!(
+            approx_eq(slope_in, (1.0 - iy) / (1.0 - ix), TEST_SLOPE_EPSILON),
+            "in slope doesn't match {} {}: {} != {}",
+            ix,
+            iy,
+            (1.0 - iy) / (1.0 - ix),
+            slope_in,
+        );
+    }
+}

--- a/src/ease/mod.rs
+++ b/src/ease/mod.rs
@@ -1,3 +1,5 @@
+mod bezier;
+
 use crate::Animatable;
 use gee::en;
 
@@ -47,4 +49,3 @@ pub fn sine_ease_out<T: en::Float>(f: T) -> T {
 pub fn sine_ease_in_out<T: en::Float>(f: T) -> T {
     -(T::cos(T::PI() * f) - T::one()) / T::two()
 }
-

--- a/src/track.rs
+++ b/src/track.rs
@@ -154,7 +154,6 @@ impl<V: Animatable<T> + en::Num, T: en::Float> Track<V, T> {
 
             let f2 = self.next_upcoming_frame(&elapsed).unwrap();
 
-            
             let f3 = if upcoming_frame_count > 1 {
                 self.second_next_upcoming_frame(&elapsed).unwrap()
             } else {


### PR DESCRIPTION
Adds `ease/bezier.rs` with bodymovin-compatible:

```rs
pub fn cubic_bezier_ease(
    ox: f64,
    oy: f64,
    ix: f64,
    iy: f64,
    t: f64,
) -> f64 {
    // ...
}
```

I added tests to verify numerical accuracy up to `1e-7` (7 decimals, i.e. 1µs for a 1s ease) and check if it behaves correctly around the endpoints and returns a smooth curve.