### PR TITLE
add inspection helpers + interrupt leftovers

### DIFF
--- a/src/combinator/interrupt.rs
+++ b/src/combinator/interrupt.rs
@@ -32,12 +32,12 @@ where
         // calculate ease
         let transition_percent_elapsed =
             (elapsed.as_secs_f64() / self.transition_t.as_secs_f64()).min(1.0);
-        let ease = cubic_bezier_ease(0.166, 0.0, 0.834, 1.0, transition_percent_elapsed);
+        let ease = cubic_bezier_ease(0.333, 0.0, 0.666, 1.0, transition_percent_elapsed);
 
         // blend a_contribution and b_contribution
         let blended_contributions = a_contribution.zip_map(b_contribution, |a, b| {
             let ac = a * en::cast::<C, _>(1.0 - ease);
-            let bc = b * en::cast::<C, _>(ease);
+            let bc = b;
             ac + bc
         });
 
@@ -71,7 +71,8 @@ where
             .zip_map(
                 a.sample(interrupt_t - Duration::from_secs_f64(SAMPLE_DELTA)),
                 |n, p| n - p,
-            ).map(|a| a * en::cast::<C, _>(0.5 / SAMPLE_DELTA));
+            )
+            .map(|a| a * en::cast::<C, _>(0.5 / SAMPLE_DELTA));
 
         let linear = Linear::new(interrupt_v, velocity);
 
@@ -96,7 +97,8 @@ where
             .zip_map(
                 a.sample(interrupt_t - Duration::from_secs_f64(SAMPLE_DELTA)),
                 |n, p| n - p,
-            ).map(|a| a * en::cast::<C, _>(0.5 / SAMPLE_DELTA));
+            )
+            .map(|a| a * en::cast::<C, _>(0.5 / SAMPLE_DELTA));
 
         let linear = Linear::new(interrupt_v, velocity);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,16 @@ pub trait Animation<V: Animatable<C>, C: en::Num> {
     {
         Cutoff::new(self, duration)
     }
+
+    fn sample_path(&self, start: Duration, end: Duration, detail: usize) -> Vec<(f64, V)> {
+        (0..detail)
+            .map(|i| {
+                let t = (i as f64) / (detail as f64);
+                let time = start + (end - start) * t;
+                (time.as_secs_f64(), self.sample(time))
+            })
+            .collect()
+    }
 }
 
 impl<V: Animatable<C>, C: en::Num> Debug for dyn Animation<V, C> {

--- a/src/spline/bezier.rs
+++ b/src/spline/bezier.rs
@@ -5,7 +5,6 @@ use crate::Animatable;
 // Newton-Raphson iterations
 const NR_ITERATIONS: usize = 3;
 
-
 pub fn cubic_bezier_ease(ox: f64, oy: f64, ix: f64, iy: f64, t: f64) -> f64 {
     // Uses a cubic 2D bezier curve to map linear interpolation time
     // to eased interpolation time.

--- a/src/spline/catmull_rom.rs
+++ b/src/spline/catmull_rom.rs
@@ -172,7 +172,6 @@ pub fn centripetal_catmull_rom<V: Animatable<C>, C: en::Num>(
     catmull_rom_value(&p0, &p1, &p2, &p3, t0, t1, t2, t3, adjusted_t)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,7 +204,8 @@ mod tests {
 
         for i in 0..=TEST_STEPS {
             let d = (i as f64) / (TEST_STEPS as f64);
-            let cr = catmull_rom_value::<_, f64>(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
+            let cr =
+                catmull_rom_value::<_, f64>(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
             let bz = cubic_bezier::<_, f64>(&b1, &b2, &b3, &b4, d);
 
             assert!(
@@ -240,7 +240,8 @@ mod tests {
 
         for i in 0..=TEST_STEPS {
             let d = (i as f64) / (TEST_STEPS as f64);
-            let cr = catmull_rom_value::<_, f64>(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
+            let cr =
+                catmull_rom_value::<_, f64>(&p1, &p2, &p3, &p4, t1, t2, t3, t4, t2 + (t3 - t2) * d);
             let bz = cubic_bezier::<_, f64>(&b1, &b2, &b3, &b4, d);
 
             assert!(

--- a/src/spline/mod.rs
+++ b/src/spline/mod.rs
@@ -3,8 +3,8 @@ pub mod catmull_rom;
 
 use gee::en;
 
-use self::catmull_rom::catmull_rom_value;
 use self::bezier::dt_cubic_bezier;
+use self::catmull_rom::catmull_rom_value;
 use crate::lerp::linear_value;
 use crate::Animatable;
 
@@ -75,7 +75,7 @@ pub fn find_index(spline_map: &SplineMap, distance: f64) -> usize {
 impl SplineMap {
     // Make a spline map to map "spline time" 0..1 to arc length 0..d.
     // Integrates with Euler's rule.
-    
+
     pub fn from_spline<V: Animatable<C>, C: en::Num, F: Fn(f64) -> V>(f: F) -> SplineMap {
         let mut steps = Vec::new();
         let mut length: f64 = 0.0;
@@ -107,7 +107,7 @@ impl SplineMap {
     // Make a spline map from a cubic bezier to map "spline time" 0..1 to arc length 0..d.
     // Uses analytic derivatives and simpson's rule for more accurate integration.
     // (only makes a difference for strongly cusped curves)
-    
+
     pub fn from_bezier<V: Animatable<C>, C: en::Num>(b0: &V, b1: &V, b2: &V, b3: &V) -> SplineMap {
         let mut steps = Vec::new();
         let mut length: f64 = 0.0;
@@ -155,8 +155,8 @@ impl SplineMap {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use self::bezier::cubic_bezier;
+    use super::*;
 
     const MATCH_TOLERANCE: f64 = 1e-3;
 
@@ -164,7 +164,6 @@ mod tests {
         lhs.is_finite() && rhs.is_finite() && ((lhs - epsilon)..(lhs + epsilon)).contains(&rhs)
     }
 
-    
     pub fn integrate_length<V: Animatable<C>, C: en::Num, F: Fn(f64) -> V>(
         from: f64,
         to: f64,

--- a/src/track.rs
+++ b/src/track.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 
 use crate::{
-    spline::{
-        SplineMap,
-        catmull_rom::{catmull_rom_to_bezier, t_values},
-    },
     interval::{BezierEase, BezierPath},
+    spline::{
+        catmull_rom::{catmull_rom_to_bezier, t_values},
+        SplineMap,
+    },
     Animatable,
 };
 use gee::en;


### PR DESCRIPTION
Tweaks for debug viz

- Add `Animation::sample_path(...)` which samples over a vec
- Add `Interval::inspect(...)` which samples the easing curve, path and metric.
- Add `Interval::ease(...)` and `Interval::transition(...)` with a default bezier ease of 1/3 (this is closest to a cosine ease).
- Switch to "premultiplied alpha" blend for interruption. This results in better interruption blends for the same reason as with RGBA.
- Fix 1 keyframe case (`start == end`)
